### PR TITLE
fix: change kontakt link to impressum

### DIFF
--- a/src/components/layout/footer.tsx
+++ b/src/components/layout/footer.tsx
@@ -18,7 +18,7 @@ const footerLinks: Link[] = [
   },
   {
     text: "Kontakt",
-    href: `${process.env.NEXT_PUBLIC_MAGAZIN_URL}/kontakt`,
+    href: `${process.env.NEXT_PUBLIC_MAGAZIN_URL}/impressum`,
   },
   {
     text: "Hilfe",


### PR DESCRIPTION
We don't have a /kontakt page, but all contact information is on /impressum. 