### PR TITLE
Erstwählerinnen-Formular erlaubt nur noch valide Geburtsjahre

### DIFF
--- a/src/components/checkout/personal-info-form-first-time-voters.tsx
+++ b/src/components/checkout/personal-info-form-first-time-voters.tsx
@@ -223,7 +223,7 @@ export function PersonalInfoFormFirstTimeVoters({
         type="number"
         label={tField("birthyear")}
         name="birthyear"
-        defaultValue={state.data.birthyear}
+        defaultValue={state.data.birthyear ?? undefined}
         required
         min={new Date().getFullYear() - 20}
         max={new Date().getFullYear() - 18}

--- a/src/components/checkout/personal-info-form-first-time-voters.tsx
+++ b/src/components/checkout/personal-info-form-first-time-voters.tsx
@@ -223,10 +223,10 @@ export function PersonalInfoFormFirstTimeVoters({
         type="number"
         label={tField("birthyear")}
         name="birthyear"
-        defaultValue={state.data.birthyear ?? new Date().getFullYear()}
+        defaultValue={state.data.birthyear}
         required
         min={new Date().getFullYear() - 20}
-        max={new Date().getFullYear()}
+        max={new Date().getFullYear() - 18}
       />
 
       <h2 className={css({ fontSize: "md", fontWeight: "medium", mt: "4" })}>


### PR DESCRIPTION
Das Formular kann nur noch abgeschickt werden, wenn das Geburtsjahr zwischen `aktuelles Jahr - 18 und -20 Jahre` liegt (Schliesst 17 Jährige mit ein, wenn sie noch in diesem Jahr volljährig werden).